### PR TITLE
Mem not path

### DIFF
--- a/audio_program_generator/apg.py
+++ b/audio_program_generator/apg.py
@@ -18,21 +18,22 @@ Description:
     script is given input file "phrases.txt", the output file will be
     "phrases.mp3".
 
-    The "mix" command is used to mix in background sounds. This command takes
-    an extra parameter, the path/filename of a sound file to be mixed in with
-    the speech file generated from the phrase file. If the sound file is shorter
-    in duration than the generated speech file, it will be looped. If it is
-    longer, it will be truncated. The resulting background sound (looped or
-    not) will be faded in and out to ensure a smooth transition. Currently,
-    only .wav files are supported.
+    Specifying the optional sound_file parameter allows the user to mix in
+    background sounds. This parameter represents the path/filename of a sound
+    ile to be mixed in with the speech file generated from the phrase file. If
+    the sound file is shorter in duration than the generated speech file, it
+    will be looped. If it is longer, it will be truncated. The resulting
+    background sound (looped or  not) will be faded in and out to ensure a
+    smooth transition. Currently, only .wav files are supported.
 
     The CLI prints out a progress bar as the phrase file is converted into gTTS
     speech snippets. However, no progress bar is shown for the secondary mix
-    step (when the mix option is chosen). There can be a significant delay in
-    going from the end of the first stage (snippet generation) to the end of
-    the second stage (mixing), primarily because of reading in the .wav file.
-    For this reason, you may want to select a sound file for mixing that
-    is small (suggested <20MB). Otherwise, be prepared to wait.
+    step (when the optional sound_file parameter is specified). There can be a
+    significant delay in going from the end of the first stage (snippet
+    generation) to the end of the second stage (mixing), primarily because of
+    reading in the .wav file. For this reason, you may want to select a sound
+    file for mixing that is small (suggested <20MB). Otherwise, be prepared to
+    wait.
 
 
 Usage:
@@ -52,7 +53,8 @@ Arguments:
     phrase_file             Name of semicolon-separated text file containing
                             phrases and silence durations.
     sound_file              Optional file to mix with the speech generated
-                            from the phrase file. Useful for background music / sounds. Must be in .wav format.
+                            from the phrase file. Useful for background music /
+                            sounds. Must be in .wav format.
 
 Example <phrase_file> format:
     Phrase One;2
@@ -99,7 +101,7 @@ class AudioProgramGenerator:
         attenuation: int = 0,
     ):
         """Initialize class instance"""
-        self.phrase_file = phrase_file  # Input file to generate speech segments
+        self.phrase_file = phrase_file  # File to generate speech segments
         self.sound_file = sound_file  # File with which to mix generated speech
         self.speech_file = None  # Generated speech/silence
         self.mix_file = None  # Mixed speeech/sound

--- a/audio_program_generator/apg.py
+++ b/audio_program_generator/apg.py
@@ -13,7 +13,7 @@ Description:
     Obviously, do not include superfluous semicolons in this file. An exception
     will occur if you do.
 
-    The script generates and saves a single MP3 file. The base name of the MP3
+    The script generates and saves a single MP3 file. The base name of the
     file is the same as the specified input file. So, for example, if the
     script is given input file "phrases.txt", the output file will be
     "phrases.mp3".
@@ -53,7 +53,8 @@ Arguments:
     phrase_file             Path/name of semicolon-separated text file
                             containing phrases and silence durations.
     sound_file              Path/name of optional wavefile to mix with the
-                            speech generated from the phrase file. Useful for background music/sounds. Must be in .wav format.
+                            speech generated from the phrase file. Useful for
+                            background music/sounds. Must be in .wav format.
 
 Example <phrase_file> format:
     Phrase One;2
@@ -177,27 +178,32 @@ def main():
 
     args = docopt(__doc__, version=f"Audio Program Generator (apg) {this_version}")
 
-    # print(args) if args["--debug"] else None
-    print(args)
+    print(args) if args["--debug"] else None
 
     phrase_file = Path(args["<phrase_file>"]) if args["<phrase_file>"] else None
     sound_file = Path(args["<sound_file>"]) if args["<sound_file>"] else None
     attenuation = args["--attenuation"] if args["--attenuation"] else 0
 
     if sound_file:
+        p = open(phrase_file, "r")
+        s = open(sound_file, "rb")
         A = AudioProgramGenerator(
-            open(phrase_file, "r"),
-            open(sound_file, "rb"),
+            p,
+            s,
             attenuation,
         )
     else:
-        A = AudioProgramGenerator(open(phrase_file, "r"))
+        p = open(phrase_file, "r")
+        A = AudioProgramGenerator(p)
 
     result = A.invoke()
 
     with open(str(phrase_file.parent / phrase_file.stem) + ".mp3", "wb") as f:
         f.write(result.getbuffer())
     result.close()
+
+    p.close()
+    s.close() if sound_file else None
 
 
 if __name__ == "__main__":

--- a/audio_program_generator/apg.py
+++ b/audio_program_generator/apg.py
@@ -50,11 +50,10 @@ Options:
     -h --help               Show this screen.
 
 Arguments:
-    phrase_file             Name of semicolon-separated text file containing
-                            phrases and silence durations.
-    sound_file              Optional file to mix with the speech generated
-                            from the phrase file. Useful for background music /
-                            sounds. Must be in .wav format.
+    phrase_file             Path/name of semicolon-separated text file
+                            containing phrases and silence durations.
+    sound_file              Path/name of optional wavefile to mix with the
+                            speech generated from the phrase file. Useful for background music/sounds. Must be in .wav format.
 
 Example <phrase_file> format:
     Phrase One;2
@@ -65,9 +64,9 @@ Author:
     Jeff Wright <jeff.washcloth@gmail.com>
 """
 import re
-import sys
 import math
-from io import BytesIO
+import pkg_resources
+from io import StringIO, BytesIO
 from pathlib import Path
 from docopt import docopt
 from gtts import gTTS
@@ -75,7 +74,9 @@ from pydub import AudioSegment
 from tqdm import tqdm
 
 
-def parse_textfile(filename: str = "") -> list:
+def parse_textfile(phrase_file_contents: str = "") -> list:
+    """Clean up user-supplied phrase file to comform with expected format"""
+
     def clean(input: str = "") -> str:
         cleaner = r"[^A-Za-z0-9\s;\v]"
         clean = re.compile(cleaner, flags=re.MULTILINE | re.UNICODE)
@@ -86,27 +87,23 @@ def parse_textfile(filename: str = "") -> list:
         captured = re.compile(capturer, flags=re.MULTILINE | re.UNICODE)
         return re.findall(captured, cleaned)
 
-    with open(filename, "r") as fh:
-        lines = fh.readlines()
-        contents = "".join(lines)
-
-    return capture(clean(contents))
+    return capture(clean(phrase_file_contents))
 
 
 class AudioProgramGenerator:
     def __init__(
         self,
-        phrase_file: Path,
-        sound_file: Path = None,
+        phrase_file: StringIO,
+        sound_file: BytesIO = None,
         attenuation: int = 0,
     ):
         """Initialize class instance"""
-        self.phrase_file = phrase_file  # File to generate speech segments
-        self.sound_file = sound_file  # File with which to mix generated speech
+        self.phrase_file = phrase_file.read()  # Fileobj to generate speech segments
+        self.sound_file = sound_file  # Fileobj to mix w/ generated speech
         self.speech_file = None  # Generated speech/silence
         self.mix_file = None  # Mixed speeech/sound
         self.attenuation = attenuation  # Attenuation value, if mixing
-        self.save_file = str(phrase_file.parent / phrase_file.stem) + ".mp3"
+        self.result = BytesIO(None)  # File-like object to store final result
 
     def _gen_speech(self):
         """Generate a combined speech file, made up of gTTS-generated speech
@@ -160,37 +157,47 @@ class AudioProgramGenerator:
             (segment2_normalized - float(seg2_atten)).fade_in(fadein).fade_out(fadeout)
         )
 
-    def invoke(self):
+    def invoke(self) -> BytesIO:
         """Generate gTTS speech snippets for each phrase; optionally mix with
         background sound-file; then save resultant mp3."""
         self._gen_speech()
+
         if self.sound_file:
             bkgnd = AudioSegment.from_file(self.sound_file, format="wav")
             self.mix_file = self._mix(self.speech_file, bkgnd, self.attenuation)
-            self.mix_file.export(self.save_file, format="mp3")
+            self.mix_file.export(self.result, format="mp3")
         else:
-            self.speech_file.export(self.save_file, format="mp3")
+            self.speech_file.export(self.result, format="mp3")
+
+        return self.result
 
 
 def main():
-    args = docopt(__doc__, version="Audio Program Generator (apg) v1.6.0")
+    this_version = pkg_resources.get_distribution("audio_program_generator").version
 
-    print(args) if args["--debug"] else None
+    args = docopt(__doc__, version=f"Audio Program Generator (apg) {this_version}")
+
+    # print(args) if args["--debug"] else None
+    print(args)
 
     phrase_file = Path(args["<phrase_file>"]) if args["<phrase_file>"] else None
     sound_file = Path(args["<sound_file>"]) if args["<sound_file>"] else None
     attenuation = args["--attenuation"] if args["--attenuation"] else 0
 
-    if not phrase_file:
-        sys.exit("Phrase file " + phrase_file + " does not exist. Quitting.")
+    if sound_file:
+        A = AudioProgramGenerator(
+            open(phrase_file, "r"),
+            open(sound_file, "rb"),
+            attenuation,
+        )
+    else:
+        A = AudioProgramGenerator(open(phrase_file, "r"))
 
-    A = AudioProgramGenerator(
-        phrase_file,
-        sound_file,
-        attenuation,
-    )
+    result = A.invoke()
 
-    A.invoke()
+    with open(str(phrase_file.parent / phrase_file.stem) + ".mp3", "wb") as f:
+        f.write(result.getbuffer())
+    result.close()
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "audio_program_generator"
-version = "1.6.0"
+version = "1.6.1"
 description = "Create an audio program from a text file containing English sentences"
 authors = ["Jeff Wright <jeff.washcloth@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
There was still some local filesystem-accessing content in the `AudioProgramGenerator` class and its helper function, `parse_textfile()`. I decided to remove this content, in order to abstract the data processing code from the underlying data. 

The function `parse_textfile` was refactored to accept the contents of a (text-based) phrase-file directly, instead of its pathname on disk. This removed the need to open the file on the local filesystem. Now the function just processes the whole file at once. The function is now called from the `AudioProgramGenerator` class using a `io.StringIO` object, instead of the filename. `parse_textfile` still returns a list of tuples representing the (phrase, duration) of each line in the phrase-file.

The `AudioProgramGenerator` class now takes in only one required parameter, "phrase_file", which is of type io.StringIO (a file-like text object). Instead of writing the resultant mp3 to disk, the invoke() method now returns the resultant mp3 as a `io.BytesIO` object, a binary stream of mp3-encoded data. Optional class constructor parameters are still "sound_file" (but now `io.BytesIO` object representing the .wav file to mix the speech snippets with); and "attenuation" (still an int). The "to_mix" boolean has been removed.

It is now the calling code's responsibility to ensure the proper open/close file-handling for the input files. In the case of the CLI, this is implemented on the local disk: the built in Docopt CLI requires `pathlib.Path` parameters as input, specifying the local disk files to pass in. In the case of cloud implementations (e.g. Heroku/DigitalOcean/Lambda), since we now avoid referencing the local filesystem, we should be able to pass in the contents of the response to the HTTP Request object as inputs to the class, and then serve the response to invoke() as an MP3 for the user to decide what to do with it. However, this is as-yet untested, and the code on those implementations will need to be reworked to use this new implementation. 