### PR TITLE
add option to hide progress bar

### DIFF
--- a/audio_program_generator/apg.py
+++ b/audio_program_generator/apg.py
@@ -120,6 +120,7 @@ class AudioProgramGenerator:
         self.speech_file = None  # Generated speech/silence
         self.mix_file = None  # Mixed speeech/sound
         self.result = BytesIO(None)  # File-like object to store final result
+        self.hide_progress_bar = kwargs.get("hide_progress_bar", False)
 
     def _gen_speech(self):
         """Generate a combined speech file, made up of gTTS-generated speech
@@ -127,7 +128,8 @@ class AudioProgramGenerator:
 
         combined = AudioSegment.empty()
 
-        for phrase, duration in tqdm(parse_textfile(self.phrase_file)):
+        for phrase, duration in tqdm(parse_textfile(self.phrase_file),
+                                     disable=self.hide_progress_bar):
 
             # Skip blank phrases or gTTS will throw exception
             if not phrase.strip():


### PR DESCRIPTION
@jeffwright13 I'd like to use this awesome tool for `pybites-alarm` (https://github.com/PyBites-Open-Source/pybites-alarm/pull/7) but the progress bar is a bit cluttering in that case so I'd like to call it like this:

```
kwargs = {"hide_progress_bar": True}
apg = AudioProgramGenerator(StringIO(alarm_text), **kwargs)
```

Should be a non disruptive change as progress bar will show by default.

Is that ok with you?